### PR TITLE
feat: Add preference for unmute delay

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -103,7 +103,7 @@ var AdBlocker = class AdBlocker {
 
         // Wait a bit to unmute, there's a delay before the next song
         // starts
-        this.muteTimeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500,
+        this.muteTimeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, this.settings.get_int('unmute-delay'),
             () => {
                 this.muteTimeout = 0;
 

--- a/prefs.js
+++ b/prefs.js
@@ -50,4 +50,18 @@ function fillPreferencesWindow(window) {
 
     adVolumeRow.add_suffix(adVolumeInput);
     adVolumeRow.set_activatable_widget(adVolumeInput);
+
+    const unmuteDelayRow = new Adw.ActionRow({
+        title: 'Volume restore delay',
+        subtitle: 'Delay in milliseconds before restoring volume after ads are finished playing',
+    });
+    prefsGroup.add(unmuteDelayRow);
+
+    const unmuteDelayInput = Gtk.SpinButton.new_with_range(0, 10000, 100);
+    unmuteDelayInput.set_valign(Gtk.Align.CENTER);
+    settings.bind('unmute-delay', unmuteDelayInput, 'value',
+        Gio.SettingsBindFlags.DEFAULT)
+
+    unmuteDelayRow.add_suffix(unmuteDelayInput);
+    unmuteDelayRow.set_activatable_widget(unmuteDelayInput);
 }

--- a/schemas/org.gnome.shell.extensions.spotify-ad-blocker.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.spotify-ad-blocker.gschema.xml
@@ -5,5 +5,8 @@
     <key name="ad-volume-percentage" type="i">
       <default>0</default>
     </key>
+    <key name="unmute-delay" type="i">
+      <default>500</default>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
The current unmute delay (500 milliseconds) is a little too short on my system. This makes it user-configurable but keeps the current default behaviour.