### PR TITLE
Unmute when extension is disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemas/gschemas.compiled


### PR DESCRIPTION
If the computer is shut down while an ad is playing, the volume will be muted. The next time the computer is booted, the volume will still be muted, but Spotify normally doesn't play ads when it's first opened, so the volume will stay muted.

This should fix that, and any other scenario in which the extension is disabled/stopped while an ad is playing.

I split unmute into two different methods: one that does the unmute, and another that does the unmute after a delay. Then when `disable` is called, the new `unmute` function can be called to immediately unmute. Feel free to refactor if you think it can be done a better way :)