### PR TITLE
fix: Call update() right away if there's a new player

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -60,6 +60,8 @@ var AdBlocker = class AdBlocker {
 
         this.player = this.media._players.get(MPRIS_PLAYER);
         if (this.player) {
+            // Update right away in case the 'changed' signal has already been emitted
+            this.update();
             this.playerId = this.player.connect('changed', this.update.bind(this));
         }
     }


### PR DESCRIPTION
... in case the 'changed' signal has already been emitted

Fixes #28