### PR TITLE
Fix: Persist volume before ads

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,8 +41,6 @@ var AdBlocker = class AdBlocker {
         this.muteTimeout = 0;
         this.enable();
 
-        this.volumeBeforeAds = this.settings.get_int('volume-before-ads');
-
         this.settings.connect('changed::show-indicator', () => {
             if (this.settings.get_boolean('show-indicator')) {
                 Main.panel._rightBox.insert_child_at_index(this.button, 0);
@@ -86,6 +84,14 @@ var AdBlocker = class AdBlocker {
 
         // spotify not found
         return [];
+    }
+
+    get volumeBeforeAds() {
+        return this.settings.get_int('volume-before-ads');
+    }
+
+    set volumeBeforeAds(newVolume) {
+        this.settings.set_int('volume-before-ads', newVolume);
     }
 
     mute() {
@@ -169,7 +175,6 @@ var AdBlocker = class AdBlocker {
             GLib.source_remove(this.muteTimeout);
             this.muteTimeout = 0;
         }
-        this.settings.set_int('volume-before-ads', this.volumeBeforeAds);
         this.playerId = 0;
         this.stopWatch();
         this.player = null;

--- a/extension.js
+++ b/extension.js
@@ -41,7 +41,7 @@ var AdBlocker = class AdBlocker {
         this.muteTimeout = 0;
         this.enable();
 
-        this.volumeBeforeAds = NOT_MUTED;
+        this.volumeBeforeAds = this.settings.get_int('volume-before-ads');
 
         this.settings.connect('changed::show-indicator', () => {
             if (this.settings.get_boolean('show-indicator')) {
@@ -169,6 +169,7 @@ var AdBlocker = class AdBlocker {
             GLib.source_remove(this.muteTimeout);
             this.muteTimeout = 0;
         }
+        this.settings.set_int('volume-before-ads', this.volumeBeforeAds);
         this.playerId = 0;
         this.stopWatch();
         this.player = null;

--- a/extension.js
+++ b/extension.js
@@ -84,8 +84,8 @@ var AdBlocker = class AdBlocker {
         if (spotify.length)
             return spotify;
 
-        // spotify not found, return default
-        return [mixer.get_default_sink()];
+        // spotify not found
+        return [];
     }
 
     mute() {
@@ -99,10 +99,10 @@ var AdBlocker = class AdBlocker {
 
         if (this.streams.length > 0) {
             this.volumeBeforeAds = this.streams[0].get_volume();
+            this.streams.map(s => s.set_volume(this.volumeBeforeAds * this.settings.get_int('ad-volume-percentage') / 100));
+            // This needs to be called after changing the volume for it to take effect
+            this.streams.map(s => s.push_volume());
         }
-        this.streams.map(s => s.set_volume(this.volumeBeforeAds * this.settings.get_int('ad-volume-percentage') / 100));
-        // This needs to be called after changing the volume for it to take effect
-        this.streams.map(s => s.push_volume());
 
         this.button.set_child(this.ad_icon);
     }
@@ -117,7 +117,7 @@ var AdBlocker = class AdBlocker {
             () => {
                 this.muteTimeout = 0;
 
-                if (this.muted) {
+                if (this.muted && this.streams.length > 0) {
                     this.streams.map(s => s.set_volume(this.volumeBeforeAds));
                     this.streams.map(s => s.push_volume());
                     this.volumeBeforeAds = NOT_MUTED;

--- a/schemas/org.gnome.shell.extensions.spotify-ad-blocker.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.spotify-ad-blocker.gschema.xml
@@ -11,5 +11,9 @@
     <key name="unmute-delay" type="i">
       <default>500</default>
     </key>
+    <!-- Used internally to persist volume before ads. Not intended to be modified by user. -->
+    <key name="volume-before-ads" type="i">
+      <default>-1</default>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Fixes #27

As per #27, the simplest solution was to just always persist volume before ads in GSettings. I've tested this for a while and I haven't encountered any bugs.

Unfortunately I saw the extension was recently updated to Gnome 45, but I have Gnome 42 and no easy way to test with Gnome 45. But looking at the code I don't think the Gnome 45 transition has any impact on this.

Here are the changes:

- Removed `volumeBeforeAds`; no longer needed as it's stored directly in GSettings. I created a getter/setter to replace it for convenience
- Removed `muted` altogether to avoid having to store it in GSettings as well. Instead, if volume before ads == -1, then that's the same as muted == false, otherwise muted == true. I added a getter for convenience
- I moved `unmuteAfterDelay` back into `unmute` as it was before since it's no longer needed as a separate method
- I moved the mute logic into the same if statement setting volume before ads to prevent possible timing bugs. Likewise for unmuting I do an additional check to prevent timing bugs.

Thanks!