### PR TITLE
Fix for mute not working

### DIFF
--- a/schemas/org.gnome.shell.extensions.spotify-ad-blocker.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.spotify-ad-blocker.gschema.xml
@@ -11,9 +11,5 @@
     <key name="unmute-delay" type="i">
       <default>500</default>
     </key>
-    <!-- Used internally to persist volume before ads. Not intended to be modified by user. -->
-    <key name="volume-before-ads" type="i">
-      <default>-1</default>
-    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Fixes https://github.com/danigm/spotify-ad-blocker/issues/33

It seems Spotify is now resetting the stream volume while ads are playing. Adds handlers to all spotify streams so if the volume is changed while an ad is playing it can be re-muted as necessary.

The logic to determine whether a mute or unmute should happen has been pulled out of the mute() and unmute() functions since it now depends on whether they're being called because the track has changed (`update()`) or the volume has changed.